### PR TITLE
update. 사과게임 합 10 찾기 로직 개선

### DIFF
--- a/code/main.py
+++ b/code/main.py
@@ -9,9 +9,6 @@ import sys
 
 print("=== 사과 게임 시작 ===")
 
-# 스크린샷 지연 시간
-screenshot_delay = 1
-
 # 현재 시간 파일명 생성
 fileName = datetime.now().strftime("%Y_%m_%d_%H_%M_%S")
 

--- a/code/ocr.py
+++ b/code/ocr.py
@@ -43,14 +43,6 @@ def check_image(image_name):
 
             resized = cv2.resize(cell_img, None, fx=2, fy=2, interpolation=cv2.INTER_LINEAR)
 
-            # resized_blurred = cv2.GaussianBlur(resized, (3, 3), 0) # 9
-            # resized_blurred = cv2.bilateralFilter(resized, 9, 75, 75)
-            # resized = cv2.medianBlur(resized, 7) # 3x3 메디안 필터 적용 (홀수 크기 사용
-
-            # kernel = np.ones((2, 2), np.uint8) # 작은 커널 사용
-            # esized = cv2.dilate(resized, kernel, iterations=1) # 팽창
-            # resized = cv2.erode(resized, kernel, iterations=1) # 침식
-
             # OCR (숫자만 허용)
             config = "--psm 10 -c tessedit_char_whitelist=123456789"
             text = pytesseract.image_to_string(resized, config=config).strip()

--- a/code/recognize.py
+++ b/code/recognize.py
@@ -1,7 +1,7 @@
 from typing import List, Tuple
 
 def is_valid_rect(x1, y1, x2, y2, ROWS, COLS):
-    return 0 <= x1 <= x2 < ROWS and 0 <= y1 <= y2 < COLS and (x2 - x1 + 1) <= 5 and (y2 - y1 + 1) <= 5
+    return 0 <= x1 <= x2 < ROWS and 0 <= y1 <= y2 < COLS
 
 def sum_and_check(grid, x1, y1, x2, y2):
     total = 0
@@ -20,9 +20,34 @@ def zero_out(grid, x1, y1, x2, y2):
 def count_cells(x1, y1, x2, y2):
     return (x2 - x1 + 1) * (y2 - y1 + 1)
 
+def count_number(grid, x1, y1, x2, y2, maxCount):
+    numberCount = 0
+    for i in range(x1, x2 + 1):
+        for j in range(y1, y2 + 1):
+            if grid[i][j] == -1:
+                return False
+            if grid[i][j] != 0:
+                numberCount += 1
+    return maxCount >= numberCount
+
 def greedy_sum10_rectangles(grid: List[List[int]]) -> List[Tuple[int, int, int, int]]:
     ROWS, COLS = len(grid), len(grid[0])
     result = []
+    # 2개 숫자 찾기 3번 반복
+    for _ in range(3):
+        for x1 in range(ROWS):
+            for y1 in range(COLS):
+                for x2 in range(x1, min(x1 + 5, ROWS)):
+                    for y2 in range(y1, min(y1 + 5, COLS)):
+
+                        if not is_valid_rect(x1, y1, x2, y2, ROWS, COLS):
+                            continue
+
+                        if sum_and_check(grid, x1, y1, x2, y2) == 10:
+                            if count_number(grid, x1, y1, x2, y2, 2):
+                                zero_out(grid, x1, y1, x2, y2)
+                                result.append((y1, x1, y2, x2))  # 반환값 포맷: (x1, y1, x2, y2) → (col,row,col,row)
+                                continue
 
     while True:
         best = None
@@ -30,8 +55,8 @@ def greedy_sum10_rectangles(grid: List[List[int]]) -> List[Tuple[int, int, int, 
 
         for x1 in range(ROWS):
             for y1 in range(COLS):
-                for x2 in range(x1, min(x1 + 5, ROWS)):
-                    for y2 in range(y1, min(y1 + 5, COLS)):
+                for x2 in range(x1, min(x1 + 10, ROWS)):
+                    for y2 in range(y1, min(y1 + 10, COLS)):
                         if not is_valid_rect(x1, y1, x2, y2, ROWS, COLS):
                             continue
                         s = sum_and_check(grid, x1, y1, x2, y2)
@@ -48,4 +73,16 @@ def greedy_sum10_rectangles(grid: List[List[int]]) -> List[Tuple[int, int, int, 
         zero_out(grid, x1, y1, x2, y2)
         result.append((y1, x1, y2, x2))  # 반환값 포맷: (x1, y1, x2, y2) → (col,row,col,row)
 
+    # zero count print
+    print("zero count:", count_zero(grid))
+
     return result
+
+# 테스트용
+def count_zero(grid):
+    count = 0
+    for row in grid:
+        for cell in row:
+            if cell == 0:
+                count += 1
+    return count

--- a/config.py
+++ b/config.py
@@ -16,7 +16,7 @@ SCREENSHOT_OFFSET_X = 435   # 스크린샷 시작 X 좌표
 SCREENSHOT_OFFSET_Y = 280   # 스크린샷 시작 Y 좌표
 SCREENSHOT_WIDTH = 1000     # 스크린샷 너비
 SCREENSHOT_HEIGHT = 585     # 스크린샷 높이
-SCREENSHOT_TAKE_DELAY = 3   # 스크린샷 찍기 전 대기 시간
+SCREENSHOT_TAKE_DELAY = 5   # 스크린샷 찍기 전 대기 시간
 
 # OCR 설정
 PYTESSERACT_CMD = '/opt/homebrew/bin/tesseract' # Tesseract 설치 경로
@@ -26,5 +26,5 @@ DRAG_OFFSET_X = 445                 # 드래그 시작 X 좌표
 DRAG_OFFSET_Y = 285                 # 드래그 시작 Y 좌표
 DRAG_CELL_WIDTH = 56                # 드래그 셀 너비
 DRAG_CELL_HEIGHT = 56               # 드래그 셀 높이
-DRAG_MOUSE_DOWN_DELAY = 0.05        # 마우스 다운 대기 시간
-DRAG_MOUSE_MOVE_TO_DURATION = 0.35  # 마우스 드래그 이동 시간
+DRAG_MOUSE_DOWN_DELAY = 0.02        # 마우스 다운 대기 시간
+DRAG_MOUSE_MOVE_TO_DURATION = 0.1  # 마우스 드래그 이동 시간


### PR DESCRIPTION
# SUMMARY
### 사과게임 합 10 찾기 로직을 개선
 - 평균점수 90점대 -> 100점대 약 10점 향상

AS-IS
 - 기존에는 좌측상단(0,0) 부터 5x5 범위만 탐색해서 10을 찾기
TO-BE
 - 0을 제외한 숫자2개의 조합으로 10을 만들 수 있는 원소부터 탐색 (3번 반복 실행)
 - 이후에 기존에 사용중이던 탐색 진행 (10x10) 범위

# DESCRIPTION
### 바꾼이유
 - 사과게임의 특성상 모든 수(1~9)가 균등하게 나옴
 기존 로직을 수행하고 결과를 분석해보니 큰 수(9,8,7) 가 많이 남아있는걸 확인
 큰 수가 많이 남은 이유는 10을 만들기에는 작은 수들의 조합으로 10을 만들기 쉽기에 작은수들을 통해 10을 만들다보니 상대적으로 큰수들을 사용할 기회가 적게되고 결과적으론 큰수들이 많이 남음
 - 고득점을 얻기 위해선 가능한 큰수들을 많이 사용한뒤 나머지 조합을 만들어야 함
  -> 2개의 수로 10만들 수 있는 방법을 우선 탐색 진행
 